### PR TITLE
ブロック固定 #15

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -80,7 +80,6 @@ function rotateMino() {
         currentMino.shape = rotatedShape;
         redrawGameboardFromGame(); // game.jsの描画関数を呼び出す
     }
-    // 壁キックなどのロジックをここに追加することも可能
 }
 
 /**
@@ -91,7 +90,7 @@ function softDrop() {
     if (canPlaceMino(currentMino, currentMino.x, currentMino.y + 1)) {
         currentMino.y++;
         redrawGameboardFromGame(); // game.jsの描画関数を呼び出す
-        // ソフトドロップで得点がある場合はここで処理
+        // TODO: ソフトドロップで得点がある場合はここで処理
     } else {
         // 下に動かせない場合は固定処理をgame.jsのlockMinoに任せる
         lockMino(); // 固定処理を呼び出す
@@ -108,7 +107,6 @@ function hardDrop() {
         y++;
     }
     currentMino.y = y;
-    // redrawGameboardFromGame(); // lockMinoが描画するので不要
     lockMino(); // game.jsの固定処理と再描画を呼び出す
 }
 
@@ -149,9 +147,6 @@ function handleKeyPress(event) {
  * この関数をmain.jsから呼び出して初期化する
  */
 export function initializeBlockControls() {
-    // 固定ブロック配列を初期化
-    // initializeFixedBlocks();
-
     // キーボードイベントリスナーを設定
     document.addEventListener('keydown', handleKeyPress);
 }

--- a/js/block.js
+++ b/js/block.js
@@ -1,63 +1,29 @@
 import {
-    BOARD_WIDTH,
-    BOARD_HEIGHT,
-    GAME_BOARD_CELL_CLASS
-} from './constants.js';
-
-import {
     currentMino,
     gameStarted,
-    boardCells
+    getGameBoardState, 
+    redrawGameBoard as redrawGameboardFromGame, 
+    lockMino 
 } from './game.js';
 
-// 固定されたブロックを保存する配列（行×列の2次元配列）
-let fixedBlocks = [];
+import { checkCollision } from './collision.js';
 
 /**
- * 固定ブロック配列を初期化
- */
-export function initializeFixedBlocks() {
-    fixedBlocks = [];
-    for (let r = 0; r < BOARD_HEIGHT; r++) {
-        fixedBlocks[r] = [];
-        for (let c = 0; c < BOARD_WIDTH; c++) {
-            fixedBlocks[r][c] = null; // null = 空、文字列 = 色クラス名
-        }
-    }
-}
-
-/**
- * ミノが指定位置に配置可能かチェック
- * @param {Object} mino - チェックするミノ
+ * ミノが指定位置に配置可能かチェック (checkCollision を使用するように変更)
+ * @param {Object} minoToCheck - チェックするミノ (形状、現在のx, yを含む)
  * @param {number} newX - 新しいX座標
  * @param {number} newY - 新しいY座標
  * @returns {boolean} - 配置可能ならtrue
- * 
- * TODO: checkCollisionで統一する
  */
-function canPlaceMino(mino, newX, newY) {
-    if (!mino || !mino.shape) return false;
-
-    for (let r = 0; r < mino.shape.length; r++) {
-        for (let c = 0; c < mino.shape[r].length; c++) {
-            if (mino.shape[r][c] === 1) {
-                const boardX = newX + c;
-                const boardY = newY + r;
-
-                // 範囲外チェック
-                if (boardX < 0 || boardX >= BOARD_WIDTH ||
-                    boardY < 0 || boardY >= BOARD_HEIGHT) {
-                    return false;
-                }
-
-                // 固定ブロックとの衝突チェック
-                if (fixedBlocks[boardY] && fixedBlocks[boardY][boardX] !== null) {
-                    return false;
-                }
-            }
-        }
-    }
-    return true;
+function canPlaceMino(minoToCheck, newX, newY) {
+    if (!minoToCheck || !minoToCheck.shape) return true; // ミノがない場合は配置可能とする（エラー回避）
+    
+    const tempMino = { // 判定用の仮ミノオブジェクト
+        ...minoToCheck,
+        x: newX,
+        y: newY
+    };
+    return !checkCollision(tempMino, getGameBoardState());
 }
 
 /**
@@ -80,52 +46,13 @@ function rotateShape(shape) {
 }
 
 /**
- * ゲームボード全体を再描画（固定ブロック + 現在のミノ）
- */
-function redrawGameBoard() {
-    if (!boardCells.length) return;
-
-    // 全セルをクリア
-    boardCells.forEach(row =>
-        row.forEach(cell => cell.className = GAME_BOARD_CELL_CLASS)
-    );
-
-    // 固定ブロックを描画
-    for (let r = 0; r < BOARD_HEIGHT; r++) {
-        for (let c = 0; c < BOARD_WIDTH; c++) {
-            if (fixedBlocks[r][c] !== null) {
-                boardCells[r][c].className = `${GAME_BOARD_CELL_CLASS} ${fixedBlocks[r][c]}`;
-            }
-        }
-    }
-
-    // 現在のミノを描画
-    if (currentMino) {
-        currentMino.shape.forEach((row, r_offset) => {
-            row.forEach((cellValue, c_offset) => {
-                if (cellValue === 1) {
-                    const targetRow = currentMino.y + r_offset;
-                    const targetCol = currentMino.x + c_offset;
-                    if (boardCells[targetRow] && boardCells[targetRow][targetCol]) {
-                        boardCells[targetRow][targetCol].className =
-                            `${GAME_BOARD_CELL_CLASS} ${currentMino.color}`;
-                    }
-                }
-            });
-        });
-    }
-}
-
-/**
  * ブロックを左に移動
  */
 function moveLeft() {
     if (!currentMino || !gameStarted) return;
-
-    const newX = currentMino.x - 1;
-    if (canPlaceMino(currentMino, newX, currentMino.y)) {
-        currentMino.x = newX;
-        redrawGameBoard();
+    if (canPlaceMino(currentMino, currentMino.x - 1, currentMino.y)) {
+        currentMino.x--;
+        redrawGameboardFromGame(); // game.jsの描画関数を呼び出す
     }
 }
 
@@ -134,11 +61,9 @@ function moveLeft() {
  */
 function moveRight() {
     if (!currentMino || !gameStarted) return;
-
-    const newX = currentMino.x + 1;
-    if (canPlaceMino(currentMino, newX, currentMino.y)) {
-        currentMino.x = newX;
-        redrawGameBoard();
+    if (canPlaceMino(currentMino, currentMino.x + 1, currentMino.y)) {
+        currentMino.x++;
+        redrawGameboardFromGame(); // game.jsの描画関数を呼び出す
     }
 }
 
@@ -147,20 +72,15 @@ function moveRight() {
  */
 function rotateMino() {
     if (!currentMino || !gameStarted) return;
-
-    const rotatedShape = rotateShape(currentMino.shape);
     const originalShape = currentMino.shape;
+    const rotatedShape = rotateShape(originalShape);
+    const tempMinoForRotation = { ...currentMino, shape: rotatedShape };
 
-    // 一時的に回転後の形状を設定してチェック
-    currentMino.shape = rotatedShape;
-
-    if (canPlaceMino(currentMino, currentMino.x, currentMino.y)) {
-        // 回転可能な場合はそのまま
-        redrawGameBoard();
-    } else {
-        // 回転不可能な場合は元に戻す
-        currentMino.shape = originalShape;
+    if (canPlaceMino(tempMinoForRotation, currentMino.x, currentMino.y)) {
+        currentMino.shape = rotatedShape;
+        redrawGameboardFromGame(); // game.jsの描画関数を呼び出す
     }
+    // 壁キックなどのロジックをここに追加することも可能
 }
 
 /**
@@ -168,11 +88,13 @@ function rotateMino() {
  */
 function softDrop() {
     if (!currentMino || !gameStarted) return;
-
-    const newY = currentMino.y + 1;
-    if (canPlaceMino(currentMino, currentMino.x, newY)) {
-        currentMino.y = newY;
-        redrawGameBoard();
+    if (canPlaceMino(currentMino, currentMino.x, currentMino.y + 1)) {
+        currentMino.y++;
+        redrawGameboardFromGame(); // game.jsの描画関数を呼び出す
+        // ソフトドロップで得点がある場合はここで処理
+    } else {
+        // 下に動かせない場合は固定処理をgame.jsのlockMinoに任せる
+        lockMino(); // 固定処理を呼び出す
     }
 }
 
@@ -181,23 +103,21 @@ function softDrop() {
  */
 function hardDrop() {
     if (!currentMino || !gameStarted) return;
-
-    // 一番下まで移動可能な位置を探す
-    let dropY = currentMino.y;
-    while (canPlaceMino(currentMino, currentMino.x, dropY + 1)) {
-        dropY++;
+    let y = currentMino.y;
+    while (canPlaceMino(currentMino, currentMino.x, y + 1)) {
+        y++;
     }
-
-    // 位置を更新
-    currentMino.y = dropY;
-    redrawGameBoard();
+    currentMino.y = y;
+    // redrawGameboardFromGame(); // lockMinoが描画するので不要
+    lockMino(); // game.jsの固定処理と再描画を呼び出す
 }
 
 /**
  * キーボードイベントリスナー
  */
 function handleKeyPress(event) {
-    if (!gameStarted) return;
+    // currentMino が null の場合も操作不可
+    if (!gameStarted || !currentMino) return;
 
     switch (event.key) {
         case 'ArrowLeft':
@@ -230,48 +150,8 @@ function handleKeyPress(event) {
  */
 export function initializeBlockControls() {
     // 固定ブロック配列を初期化
-    initializeFixedBlocks();
+    // initializeFixedBlocks();
 
     // キーボードイベントリスナーを設定
     document.addEventListener('keydown', handleKeyPress);
 }
-
-/**
- * 現在のミノを固定ブロックとして配置
- * この関数は他のモジュールから呼び出される想定
- */
-export function fixCurrentMino() {
-    if (!currentMino) return;
-
-    currentMino.shape.forEach((row, r_offset) => {
-        row.forEach((cellValue, c_offset) => {
-            if (cellValue === 1) {
-                const targetRow = currentMino.y + r_offset;
-                const targetCol = currentMino.x + c_offset;
-                if (targetRow >= 0 && targetRow < BOARD_HEIGHT &&
-                    targetCol >= 0 && targetCol < BOARD_WIDTH) {
-                    fixedBlocks[targetRow][targetCol] = currentMino.color;
-                }
-            }
-        });
-    });
-}
-
-/**
- * 衝突判定のユーティリティ関数（他のモジュールから利用可能）
- */
-export function checkCollision(mino, newX, newY) {
-    return !canPlaceMino(mino, newX, newY);
-}
-
-/**
- * 固定ブロック配列を取得（他のモジュールから参照可能）
- */
-export function getFixedBlocks() {
-    return fixedBlocks;
-}
-
-/**
- * ゲームボード再描画関数をエクスポート（game.jsから利用）
- */
-export { redrawGameBoard };

--- a/js/block.js
+++ b/js/block.js
@@ -32,6 +32,8 @@ export function initializeFixedBlocks() {
  * @param {number} newX - 新しいX座標
  * @param {number} newY - 新しいY座標
  * @returns {boolean} - 配置可能ならtrue
+ * 
+ * TODO: checkCollisionで統一する
  */
 function canPlaceMino(mino, newX, newY) {
     if (!mino || !mino.shape) return false;

--- a/js/collision.js
+++ b/js/collision.js
@@ -1,0 +1,51 @@
+import { 
+    BOARD_WIDTH, 
+    BOARD_HEIGHT 
+} from './constants.js';
+
+/**
+ * 指定されたミノが、指定された位置で衝突するかどうかを判定する
+ * ボードの境界（底、左右）または他の固定ブロックとの衝突をチェックする
+ * @param {object} mino - 判定対象のミノオブジェクト(shape, x, y を持つ)
+ * @param {Array<Array<any>>} boardState - ゲームボードの状態配列 (0は空、その他はブロックの色など)
+ * @returns {boolean} 衝突する場合はtrue,しない場合はfalse
+ * 
+ * TODO: block.jsにある同名の関数との関連を考える（オーバーロードする？）
+ */
+export function checkCollision(mino, boardState) {
+    if (!mino || !mino.shape) { // ミノや形状データがなければ判定不可（念のため）
+        return false;
+    }
+    const shape = mino.shape;
+    const x = mino.x;
+    const y = mino.y;
+
+    for (let r = 0; r < shape.length; r++) {
+        for (let c = 0; c < shape[r].length; c++) {
+            if (shape[r][c] === 1) { // ミノのブロックがある部分のみチェック
+                const boardX = x + c; // グリッド上のX座標
+                const boardY = y + r; // グリッド上のY座標
+
+                // ボードの底を超えたか
+                if (boardY >= BOARD_HEIGHT) {
+                    return true;
+                }
+                // ボードの左右の壁を超えたか
+                if (boardX < 0 || boardX >= BOARD_WIDTH) {
+                    return true;
+                }
+                // ボードの上部より上は衝突としない (Y < 0 のケース)
+                // ただし、その位置に固定ブロックがあることは通常ない前提。
+                if (boardY < 0) {
+                    continue; // このセルは盤面外なので、固定ブロックとの衝突はチェックしない
+                }
+                // 他の固定されたブロックに衝突したか
+                // boardState[boardY] が存在し、かつその位置が空(0)でない場合
+                if (boardState[boardY] && boardState[boardY][boardX] !== 0) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}

--- a/js/game.js
+++ b/js/game.js
@@ -118,7 +118,7 @@ export function drawMinoOnGrid(mino, gridCellArray, baseCellClass) {
 }
 
 /**
- * ミノをゲームボードに固定する関数
+ * ミノを固定した後、新しいミノをスポーンし、盤面を再描画
  */
 function lockMino() {
     if (!currentMino) return;
@@ -135,7 +135,14 @@ function lockMino() {
         });
     });
     currentMino = null; // 固定したら操作対象のミノをなくす
-    // TODO: 新しいミノを出す
+
+    // 新しいミノを出現させる処理
+    spawnNewMino(); 
+    
+    // 固定された盤面と新しいミノ（ゲームオーバーでなければ）を描画
+    redrawGameBoard(); 
+
+    // TODO: ライン消去処理
 }
 
 
@@ -198,7 +205,7 @@ export function displayNextMino() {
 }
 
 /*
-* メインフィールドとNextにミノを配置する
+* 新しいミノをスポーンし、ゲームオーバー判定を行う
 */
 export function spawnNewMino() {
     currentMino = nextMino;
@@ -208,6 +215,17 @@ export function spawnNewMino() {
         currentMino.y = 0;
         const shapeWidth = currentMino.shape[0] ? currentMino.shape[0].length : 0;
         currentMino.x = Math.floor((BOARD_WIDTH - shapeWidth) / 2);
+
+        // ★追加: ゲームオーバー判定 (新しいミノが出現位置で即衝突する場合)
+        if (checkCollision(currentMino, gameBoardState)) {
+            gameStarted = false; // ゲーム終了状態
+            if (gameOverMessage) { // DOM要素が初期化されていれば
+                gameOverMessage.classList.remove('hidden');
+                // TODO: finalScoreDisplay にスコアを表示するなどの処理
+            }
+            currentMino = null; // 操作ミノをなくす
+            // ゲームループは gameLoop関数内の gameStarted チェックで停止する
+        }
 
         // 重複描画を避けるため、spawnNewMino時の描画はredrawGameBoardに任せる
         // boardCells.forEach(row => row.forEach(cell => cell.className = GAME_BOARD_CELL_CLASS));
@@ -287,7 +305,11 @@ export function handleStartButtonClick() {
         spawnNewMino();          // currentMino と次の nextMino を準備
         redrawGameBoard();       // 初期配置の currentMino を描画
 
-        // ゲームループを開始
-        startGameLoop();
+        // ゲームオーバーでなければループ開始
+        if (gameStarted) {
+            startGameLoop();
+        }
     }
+
+    // TODO: ゲーム中に再度押された場合のポーズ/再開処理
 }

--- a/js/game.js
+++ b/js/game.js
@@ -139,8 +139,6 @@ export function lockMino() {
             }
         });
     });
-    // currentMino = null; // spawnNewMinoで上書きされるので、ここでnullにしなくても良い
-
     // 新しいミノを出現させる処理
     spawnNewMino(); 
     
@@ -229,12 +227,7 @@ export function spawnNewMino() {
                 // TODO: finalScoreDisplay にスコアを表示するなどの処理
             }
             currentMino = null; // 操作ミノをなくす
-            // ゲームループは gameLoop関数内の gameStarted チェックで停止する
         }
-
-        // 重複描画を避けるため、spawnNewMino時の描画はredrawGameBoardに任せる
-        // boardCells.forEach(row => row.forEach(cell => cell.className = GAME_BOARD_CELL_CLASS));
-        // drawMinoOnGrid(currentMino, boardCells, GAME_BOARD_CELL_CLASS);
     }
     displayNextMino();
 }

--- a/js/game.js
+++ b/js/game.js
@@ -25,6 +25,11 @@ let gameLoopId = null;
 // 固定されたブロックの状態を保持する配列
 let gameBoardState = [];
 
+// block.jsから盤面状態を参照するためのゲッター関数
+export function getGameBoardState() {
+    return gameBoardState;
+}
+
 /*
 * 取得したDOM要素を初期化する（main.js側で渡す想定）
 */
@@ -120,7 +125,7 @@ export function drawMinoOnGrid(mino, gridCellArray, baseCellClass) {
 /**
  * ミノを固定した後、新しいミノをスポーンし、盤面を再描画
  */
-function lockMino() {
+export function lockMino() {
     if (!currentMino) return;
 
     currentMino.shape.forEach((row, rOffset) => {
@@ -134,7 +139,7 @@ function lockMino() {
             }
         });
     });
-    currentMino = null; // 固定したら操作対象のミノをなくす
+    // currentMino = null; // spawnNewMinoで上書きされるので、ここでnullにしなくても良い
 
     // 新しいミノを出現させる処理
     spawnNewMino(); 
@@ -149,7 +154,7 @@ function lockMino() {
 /**
  * 自動落下に際し、ゲームボード全体をクリアし現在のミノを描画する
  */
-function redrawGameBoard() {
+export function redrawGameBoard() {
     // boardCellsが未初期化なら何もしない
     if (!boardCells.length) return;
 
@@ -216,7 +221,7 @@ export function spawnNewMino() {
         const shapeWidth = currentMino.shape[0] ? currentMino.shape[0].length : 0;
         currentMino.x = Math.floor((BOARD_WIDTH - shapeWidth) / 2);
 
-        // ★追加: ゲームオーバー判定 (新しいミノが出現位置で即衝突する場合)
+        // ゲームオーバー判定 (新しいミノが出現位置で即衝突する場合)
         if (checkCollision(currentMino, gameBoardState)) {
             gameStarted = false; // ゲーム終了状態
             if (gameOverMessage) { // DOM要素が初期化されていれば
@@ -245,6 +250,7 @@ function moveMinoDown() {
         lockMino();
     } else {
         currentMino.y++;
+        redrawGameBoard(); // 自動落下時はここで再描画
     }
     redrawGameBoard(); // 移動後または固定後の盤面を再描画
 }

--- a/js/game.js
+++ b/js/game.js
@@ -290,7 +290,7 @@ function startGameLoop() {
 }
 
 /*
-* ボタンクリック時の開始関数
+* スタートボタンクリック時の開始関数
 */
 export function handleStartButtonClick() {
     if (!gameStarted) { // 既に開始していたら何もしない
@@ -311,4 +311,17 @@ export function handleStartButtonClick() {
     }
 
     // TODO: ゲーム中に再度押された場合のポーズ/再開処理
+}
+
+/*
+* ゲームオーバー時のリスタート関数
+*/
+export function handleReStartButtonClick() {
+    // ゲームオーバー画面を閉じる
+    if(gameOverMessage) {
+        gameOverMessage.classList.add('hidden');
+    }
+
+    // ゲームの状態を初期化する
+    initializeBoardAndNextArea(); 
 }

--- a/js/game.js
+++ b/js/game.js
@@ -9,6 +9,8 @@ import {
     NEXT_AREA_CELL_CLASS
 } from './constants.js';
 
+import { checkCollision } from './collision.js';
+
 // 外部で定義される変数を格納用としてexport
 export let boardCells = [];
 export let nextMinoCells = [];
@@ -19,6 +21,9 @@ export let gameStarted = false;
 // ゲームループ関連の変数
 let lastDropTime = 0;
 let gameLoopId = null;
+
+// 固定されたブロックの状態を保持する配列
+let gameBoardState = [];
 
 /*
 * 取得したDOM要素を初期化する（main.js側で渡す想定）
@@ -57,6 +62,10 @@ export function createGridCells(rows, cols, containerElement, cellBaseClass) {
 export function initializeBoardAndNextArea() {
     boardCells = createGridCells(BOARD_HEIGHT, BOARD_WIDTH, gameBoard, GAME_BOARD_CELL_CLASS);
     nextMinoCells = createGridCells(NEXT_AREA_SIZE, NEXT_AREA_SIZE, nextMinoArea, NEXT_AREA_CELL_CLASS);
+
+    // 固定されたブロックの状態を初期化 (全て0にする)
+    gameBoardState = Array.from({ length: BOARD_HEIGHT }, () => Array(BOARD_WIDTH).fill(0));
+
     scoreDisplay.textContent = '0';
     startPauseButton.textContent = 'Start';
     gameStarted = false;
@@ -70,6 +79,10 @@ export function initializeBoardAndNextArea() {
     // ゲーム状態もリセット
     currentMino = null;
     nextMino = null;
+
+    // 初期化時にプレイフィールドとNextをクリア表示
+    redrawGameBoard(); 
+    displayNextMino(); 
 }
 
 /*
@@ -105,16 +118,47 @@ export function drawMinoOnGrid(mino, gridCellArray, baseCellClass) {
 }
 
 /**
+ * ミノをゲームボードに固定する関数
+ */
+function lockMino() {
+    if (!currentMino) return;
+
+    currentMino.shape.forEach((row, rOffset) => {
+        row.forEach((cellValue, cOffset) => {
+            if (cellValue === 1) {
+                const boardX = currentMino.x + cOffset;
+                const boardY = currentMino.y + rOffset;
+                if (boardY >= 0 && boardY < BOARD_HEIGHT && boardX >= 0 && boardX < BOARD_WIDTH) {
+                    gameBoardState[boardY][boardX] = currentMino.color;
+                }
+            }
+        });
+    });
+    currentMino = null; // 固定したら操作対象のミノをなくす
+    // TODO: 新しいミノを出す
+}
+
+
+/**
  * 自動落下に際し、ゲームボード全体をクリアし現在のミノを描画する
  */
 function redrawGameBoard() {
-    // TODO: 固定されたブロックの描画を考慮する
-
     // boardCellsが未初期化なら何もしない
     if (!boardCells.length) return;
 
     // ボード全体をクリア
     boardCells.forEach(row => row.forEach(cell => cell.className = GAME_BOARD_CELL_CLASS));
+
+    // 固定するブロックの位置を設定する
+    for (let r = 0; r < BOARD_HEIGHT; r++) {
+        for (let c = 0; c < BOARD_WIDTH; c++) {
+            if (gameBoardState[r][c] !== 0) {
+                if (boardCells[r] && boardCells[r][c]) {
+                    boardCells[r][c].className = `${GAME_BOARD_CELL_CLASS} ${gameBoardState[r][c]}`;
+                }
+            }
+        }
+    }
 
     // 現在のミノを描画
     if (currentMino) {
@@ -173,12 +217,18 @@ export function spawnNewMino() {
 }
 
 /**
- * 現在のミノを1マス下に単純に移動させる処理。
+ * 現在のミノを1マス下に動かす。衝突すれば固定する。
  */
-function simpleMoveMinoDown() {
+function moveMinoDown() {
     if (!currentMino || !gameStarted) return;
-    currentMino.y++; // Y座標を1増やす
-    redrawGameBoard(); // 画面を再描画
+    const testMino = { ...currentMino, y: currentMino.y + 1 };
+
+    if (checkCollision(testMino, gameBoardState)) { // インポートしたcheckCollisionを使用
+        lockMino();
+    } else {
+        currentMino.y++;
+    }
+    redrawGameBoard(); // 移動後または固定後の盤面を再描画
 }
 
 /**
@@ -198,7 +248,7 @@ function gameLoop(timestamp) {
     // 経過時間(Time)が、設定した落下間隔(DROP_INTERVAL)を超えたかどうかを確認する
     if (elapsedTime > DROP_INTERVAL) {
         // ブロックを1マス下に落とす処理を実行
-        simpleMoveMinoDown();
+        moveMinoDown();
         // 最終落下時刻を現在の時刻に更新し、次回の落下タイミングの基準にする
         lastDropTime = timestamp;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -4,8 +4,8 @@ import {
 	initGameDOMElements
 } from './game.js';
 
-
 import { initializeBlockControls } from './block.js';
+
 /*
 ================================================================================
   DOM要素の取得

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 import {
 	initializeBoardAndNextArea,
 	handleStartButtonClick,
+	handleReStartButtonClick,
 	initGameDOMElements
 } from './game.js';
 
@@ -16,6 +17,7 @@ const scoreDisplay = document.getElementById('score-display');
 const startPauseButton = document.getElementById('start-pause-button');
 const nextMinoArea = document.getElementById('next-mino-area');
 const gameOverMessage = document.getElementById('game-over-message');
+const restartButton = document.getElementById('restart-button');
 
 // DOM参照をgame.jsへ渡す
 initGameDOMElements({
@@ -31,7 +33,11 @@ initGameDOMElements({
   イベントリスナーの設定
 ================================================================================
 */
+// ゲームスタート
 startPauseButton.addEventListener('click', handleStartButtonClick);
+
+// ゲームオーバー時のリトライ
+restartButton.addEventListener('click', handleReStartButtonClick);
 
 /*
 ================================================================================


### PR DESCRIPTION
Closes #15
 
## 概要
以下の２点の実装がメインです

1. 一番下に着手した場合、または既に着地したブロックの上に重なった場合にその位置でミノを固定する
2. 一番下に着手した場合、または既に着地したブロックの上に重なった場合にNextエリアのミノをメインのフィールドに表示させ、自動落下させる

https://github.com/user-attachments/assets/c91f646a-fae5-40ee-844f-a89b02a53c4b

## 備考

- ゲームオーバーの判定もついでに実装しました。（※スコアの計算とリスタートの実装はまだ）
![image](https://github.com/user-attachments/assets/410e5e87-f9b6-4900-88eb-22a9785bc33c)

- game.jsとblock.jsで実装内容が重複していることが原因で以下の不具合が見られたので、block.jsの画面描写に関するロジックを前者に委ねる形にしています（block.jsは主に矢印キー操作の役割を担う形になっています）

（見られた不具合）
1. すでに着地しているブロックとの衝突判定がおかしく、適切にブロックが積み重ならない
2. キーボードの矢印キー押下で自動落下するミノを移動させることができるが、矢印キー押下と同時にすでに着地しているミノが点滅する

- リスタートもついでにこのコミットに含めました